### PR TITLE
Treat long searches as a reference and go direct to certificate

### DIFF
--- a/prototype-03/app/routes.js
+++ b/prototype-03/app/routes.js
@@ -19,21 +19,30 @@ router.get('/certificate', function(req, res, next) {
 });
 
 
-var sortedArray = [];
-var lastCheckedPostcode = '';
+const MAX_POSTCODE_LENGTH = 7;
 
 router.post('/certificate/results', function(req, res) {
   if(req.session.data['postcode-or-reference']){
-      delete req.session.data['postcode-or-reference']
-      res.render('certificate/results', {
-        addresses: req.app.locals.data //static dummy data
-      });
-
+     postcodeOrRef = req.session.data['postcode-or-reference']
+     delete req.session.data['postcode-or-reference']
+     // Remove whitespace from submitted string and check length; if long treat it as a ref and go direct to certificate
+     if(postcodeOrRef.replace(/\s/g, "").length > MAX_POSTCODE_LENGTH) {
+         res.redirect("/certificate/results/" + randomIntFromInterval(1, req.app.locals.data.length))
+     }
+     else {
+        res.render('certificate/results', {
+          addresses: req.app.locals.data //static dummy data
+        });
+     }
   }else{
     filterCertTypes(req, res);
   }
 });
 
+function randomIntFromInterval(min,max) // min and max included
+{
+  return Math.floor(Math.random()*(max-min+1)+min);
+}
 
 function filterCertTypes(req, res){
   var arr = [];


### PR DESCRIPTION
The search box says "Postcode or reference" but up until now
everything took the user to the postcode results page.

This updates things so that anything longer than 7 characters
(after spaces are stripped out) is treated as a reference number
and takes the user directly to a random certificate page.