### PR TITLE
Fixes for filters and search by assessor 

### DIFF
--- a/prototype-03/app/data/data-generator.js
+++ b/prototype-03/app/data/data-generator.js
@@ -4,7 +4,7 @@ module.exports = {
 
     const firstNames = ['Alistair', 'Emily', 'Jake', 'Jessica', 'Katy', 'Kevin', 'Matt', 'Sudheer', 'Abi', 'Paul', 'Stephanie', 'Tom']
     const lastNames = ['Davidson', 'Hill', 'Docherty', 'Armstrong', 'Keenoy', 'Anderson', 'Edupuganti', 'Thorpe', 'Downey', 'Buck', 'Bates']
-    const schemes = ['EES/', 'STRO', 'ECMK']
+    const schemes = ['EES-', 'STRO', 'ECMK']
     const certificates = [
       {
         title: 'residential EPC',

--- a/prototype-03/app/data/data-generator.js
+++ b/prototype-03/app/data/data-generator.js
@@ -11,15 +11,15 @@ module.exports = {
         type: 'residential'
       }, {
         title: 'non-residential EPC',
-        type: 'nonresidential'
+        type: 'nonresepc'
       },
       {
         title: 'DEC',
-        type: 'dec'
+        type: 'displayenergy'
       },
       {
         title: 'AC-CERT',
-        type: 'acu'
+        type: 'accert'
       }
     ]
 

--- a/prototype-03/app/routes.js
+++ b/prototype-03/app/routes.js
@@ -62,7 +62,7 @@ function filterAssessors(req, res){
 }
 
 router.get('/assessor/:id', (req, res) => {
-  res.render('assessor/view', { assessor: req.session.data['assessors'][req.params.id] })
+  res.render('assessor/view', { assessor: req.session.data['assessors'].filter(assessor => assessor.accreditation_number == req.params.id)[0] })
 })
 
 router.get('/certificate', function(req, res, next) {

--- a/prototype-03/app/routes.js
+++ b/prototype-03/app/routes.js
@@ -56,6 +56,7 @@ function filterAssessors(req, res){
   filterString = allSelectedTypes.filter(function(item) {return item !== "nonresidential"}).map(item => assessorNiceNames[item]).join(", ");
   res.render('assessor/results', {
     results: results,
+    allSelectedTypes: allSelectedTypes,
     filterString: filterString
   });
 }

--- a/prototype-03/app/routes.js
+++ b/prototype-03/app/routes.js
@@ -13,7 +13,8 @@ router.get('/assessor/results', (req, res) => {
     delete req.session.data['postcode'];
     // Remove whitespace from submitted string and check length; if long treat it as a ref and go direct to assessor
     if(postcodeOrRef.replace(/\s/g, "").length > MAX_POSTCODE_LENGTH) {
-        res.redirect("/assessor/" + randomIntFromInterval(0, req.session.data['assessors'].length -1));
+        var randomAssessorRef = req.session.data['assessors'].map(assessor => assessor.accreditation_number)[randomIntFromInterval(0, req.session.data['assessors'].length -1)];
+        res.redirect("/assessor/" + randomAssessorRef);
     } else {
         res.render('assessor/results', { results: req.session.data['assessors'] });
     }

--- a/prototype-03/app/routes.js
+++ b/prototype-03/app/routes.js
@@ -115,7 +115,7 @@ function filterCertTypes(req, res){
 
   res.render('certificate/results', {
     addresses: arr,
-    certificates_description: selected_cert_types.join(", ")
+    certificates_description: selected_cert_types.length == 4 ? "all energy performance" : selected_cert_types.join(", ")
   });
 }
 

--- a/prototype-03/app/routes.js
+++ b/prototype-03/app/routes.js
@@ -44,6 +44,11 @@ function filterAssessors(req, res){
   if (assessorTypes.includes("nonresidential") && !nonResTypes.length){
     nonResTypes = ["nonresepc","displayenergy","accert"];
   }
+  // If non-residential types chosen but not the high-level non-residential box then check the nonresidential box too
+  else if (nonResTypes.length && ! assessorTypes.includes("nonresidential")){
+    assessorTypes.push("nonresidential")
+  }
+
   var allSelectedTypes = assessorTypes.concat(nonResTypes);
 
   for (var i=0;i<req.session.data['assessors'].length;i++){

--- a/prototype-03/app/routes.js
+++ b/prototype-03/app/routes.js
@@ -88,7 +88,12 @@ router.post('/certificate/results', function(req, res) {
           addresses: req.app.locals.data //static dummy data
         });
      }
-  }else{
+  }
+  // If all filters have been deselected and resubmitted fall back to full list
+  else if(typeof req.session.data['certificate-type'] == "undefined"){
+    res.render('certificate/results', { addresses: req.app.locals.data });
+  }
+  else{
     filterCertTypes(req, res);
   }
 });

--- a/prototype-03/app/views/assessor/results.html
+++ b/prototype-03/app/views/assessor/results.html
@@ -63,19 +63,19 @@
               {
                 value: "nonresepc",
                 text: "Energy performance certificates (EPC)",
-                checked: (data['type'] and data['nonrestype'] and 'nonresepc' in data['nonrestype'] and 'nonresidential' in data['type']),
+                checked: (allSelectedTypes and 'nonresepc' in allSelectedTypes),
                 disabled: (data['type'] and 'nonresidential' not in data['type'])
               },
               {
                 value: "displayenergy",
                 text: "Display energy certificates (DEC)",
-                checked: (data['type'] and data['nonrestype'] and 'displayenergy' in data['nonrestype'] and 'nonresidential' in data['type']),
+                checked: (allSelectedTypes and 'displayenergy' in allSelectedTypes),
                 disabled: (data['type'] and 'nonresidential' not in data['type'])
               },
               {
                 value: "accert",
                 text: "Air conditioning inspection certificates (AC-CERT)",
-                checked: (data['type'] and data['nonrestype'] and 'accert' in data['nonrestype'] and 'nonresidential' in data['type']),
+                checked: (allSelectedTypes and 'accert' in allSelectedTypes),
                 disabled: (data['type'] and 'nonresidential' not in data['type'])
               }
             ]

--- a/prototype-03/app/views/assessor/results.html
+++ b/prototype-03/app/views/assessor/results.html
@@ -90,7 +90,7 @@
       </div>
 
     <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-body">There are {{ results.length }} results for <strong>{{ data['type'] }} assessors</strong></p>
+      <p class="govuk-body">There are {{ results.length }} results for <strong>{{ filterString or "all" }} assessors</strong></p>
 
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 

--- a/prototype-03/app/views/assessor/results.html
+++ b/prototype-03/app/views/assessor/results.html
@@ -65,22 +65,19 @@
                 id: "nonresepc",
                 value: "nonresepc",
                 text: "Energy performance certificates (EPC)",
-                checked: (allSelectedTypes and 'nonresepc' in allSelectedTypes),
-                disabled: (not (allSelectedTypes and 'nonresidential' in allSelectedTypes))
+                checked: (allSelectedTypes and 'nonresepc' in allSelectedTypes)
               },
               {
                 id: "displayenergy",
                 value: "displayenergy",
                 text: "Display energy certificates (DEC)",
-                checked: (allSelectedTypes and 'displayenergy' in allSelectedTypes),
-                disabled: (not (allSelectedTypes and 'nonresidential' in allSelectedTypes))
+                checked: (allSelectedTypes and 'displayenergy' in allSelectedTypes)
               },
               {
                 id: "accert",
                 value: "accert",
                 text: "Air conditioning inspection certificates (AC-CERT)",
-                checked: (allSelectedTypes and 'accert' in allSelectedTypes),
-                disabled: (not (allSelectedTypes and 'nonresidential' in allSelectedTypes))
+                checked: (allSelectedTypes and 'accert' in allSelectedTypes)
               }
             ]
           }) }}
@@ -129,5 +126,6 @@
     }
 
     checkbox.addEventListener('click', toggleNonResidentialFilters);
+    toggleNonResidentialFilters();
   </script>
 {% endblock %}

--- a/prototype-03/app/views/assessor/results.html
+++ b/prototype-03/app/views/assessor/results.html
@@ -38,12 +38,12 @@
               {
                 value: "residential",
                 text: "Residential",
-                checked: (data['type'] and 'residential' in data['type'])
+                checked: (allSelectedTypes and 'residential' in allSelectedTypes)
               },
               {
                 value: "nonresidential",
                 text: "Non-residential",
-                checked: (data['type'] and 'nonresidential' in data['type'])
+                checked: (allSelectedTypes and 'nonresidential' in allSelectedTypes)
               }
             ]
           }) }}

--- a/prototype-03/app/views/assessor/results.html
+++ b/prototype-03/app/views/assessor/results.html
@@ -41,6 +41,7 @@
                 checked: (allSelectedTypes and 'residential' in allSelectedTypes)
               },
               {
+                id: "nonresidential-checkbox",
                 value: "nonresidential",
                 text: "Non-residential",
                 checked: (allSelectedTypes and 'nonresidential' in allSelectedTypes)
@@ -61,22 +62,25 @@
             },
             items: [
               {
+                id: "nonresepc",
                 value: "nonresepc",
                 text: "Energy performance certificates (EPC)",
                 checked: (allSelectedTypes and 'nonresepc' in allSelectedTypes),
-                disabled: (data['type'] and 'nonresidential' not in data['type'])
+                disabled: (not (allSelectedTypes and 'nonresidential' in allSelectedTypes))
               },
               {
+                id: "displayenergy",
                 value: "displayenergy",
                 text: "Display energy certificates (DEC)",
                 checked: (allSelectedTypes and 'displayenergy' in allSelectedTypes),
-                disabled: (data['type'] and 'nonresidential' not in data['type'])
+                disabled: (not (allSelectedTypes and 'nonresidential' in allSelectedTypes))
               },
               {
+                id: "accert",
                 value: "accert",
                 text: "Air conditioning inspection certificates (AC-CERT)",
                 checked: (allSelectedTypes and 'accert' in allSelectedTypes),
-                disabled: (data['type'] and 'nonresidential' not in data['type'])
+                disabled: (not (allSelectedTypes and 'nonresidential' in allSelectedTypes))
               }
             ]
           }) }}
@@ -110,4 +114,20 @@
 
   </div>
 
+  <script>
+    var checkbox = document.getElementById("nonresidential-checkbox");
+    function toggleNonResidentialFilters() {
+      if (checkbox.checked == false) {
+        document.getElementById('nonresepc').disabled = true;
+        document.getElementById('displayenergy').disabled = true;
+        document.getElementById('accert').disabled = true;
+      } else {
+        document.getElementById('nonresepc').disabled = false;
+        document.getElementById('displayenergy').disabled = false;
+        document.getElementById('accert').disabled = false;
+      }
+    }
+
+    checkbox.addEventListener('click', toggleNonResidentialFilters);
+  </script>
 {% endblock %}

--- a/prototype-03/app/views/assessor/results.html
+++ b/prototype-03/app/views/assessor/results.html
@@ -97,7 +97,7 @@
       {% for assessor in results %}
         <ul class="govuk-list">
           <li>
-            <a class="govuk-link" href="/assessor/{{ loop.index0 }}">{{ assessor.full_name }}</a>
+            <a class="govuk-link" href="/assessor/{{ assessor.accreditation_number }}">{{ assessor.full_name }}</a>
           </li>
           <li><strong>Accreditation number: {{ assessor.accreditation_number }}</strong></li>
           <li>Certificate types: {{ assessor.certificatesString }}</li>

--- a/prototype-03/app/views/certificate/results.html
+++ b/prototype-03/app/views/certificate/results.html
@@ -69,8 +69,8 @@ Energy certificates for SW1P 3BU<!-- {{ data['postcode-or-reference'] | upper}} 
   <div class="govuk-grid-column-two-thirds">
     {% if addresses.length %}
     <p class="govuk-body">There are {{ addresses.length }} results for <span class="govuk-!-font-weight-bold">
-      {{ certificates_description if certificates_description else "all energy performance
-        certificates" }}</span></p>
+      {{ certificates_description if certificates_description else "all energy performance" }} certificates</span>
+    </p>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
     <table class="govuk-table">


### PR DESCRIPTION
There's a few improvements here:
 * Search for an assessor by reference (anything longer than 7 characters in the search box) takes you directly to a random assessor page
 * Filters work on the assessor results page
 * Non-residential type filters are disabled unless the non-residential box is ticked
 * There is a bunch of extra logic to make the filters for non-residential behave sensibly that is unnecessary now the front end enforces selecting non-residential before you can select non-residential types, but I figure it doesn't hurt to leave it in there... it probably helps for users without JS
 * Unchecking certificate filters and re-submitting now works, whereas previously it threw an error
